### PR TITLE
ROCm support on Linux and Windows

### DIFF
--- a/opencl_docker/__main__.py
+++ b/opencl_docker/__main__.py
@@ -37,8 +37,7 @@ def install_dependencies(dockerfile: Dockerfile, args: Any):
                     "gdb",
                     "valgrind",
                     "oclgrind",
-                    "python3-numpy",
-                    "netcat-openbsd"
+                    "python3-numpy"
                 ]
     
     if "qualcomm" in args.image:
@@ -51,6 +50,12 @@ def install_dependencies(dockerfile: Dockerfile, args: Any):
             "ocl-icd-libopencl1",
             "ocl-icd-dev",
             "ocl-icd-opencl-dev"])
+    
+    if "dsmlp" in args.tag:
+        dependencies.extend([
+            "openssh-server",
+            "netcat-openbsd"
+        ])
 
     # Ubuntu 22.04 needs ocl-icd from this PPA in order to support newer versions of POCL
     if "22.04" in args.image:

--- a/opencl_docker/__main__.py
+++ b/opencl_docker/__main__.py
@@ -37,6 +37,8 @@ def install_dependencies(dockerfile: Dockerfile, args: Any):
                     "gdb",
                     "valgrind",
                     "oclgrind",
+                    "python3-numpy",
+                    "netcat-openbsd"
                 ]
     
     if "qualcomm" in args.image:

--- a/opencl_docker/__main__.py
+++ b/opencl_docker/__main__.py
@@ -83,15 +83,13 @@ def install_pocl(dockerfile: Dockerfile, args: Any):
                      rm -rf /pocl")
     
 def install_cuda_dsmlp(dockerfile: Dockerfile, args: Any):
-    # Hack to port old cuda version forward
+    # Hack to port old cuda version forward.
+    # The DSMLP has old drivers for the 1080Ti and there is
+    # a possible compat issue with newer POCL versions.
+    # These commands are only good enough for another CUDA 12 base image
     if "dsmlp" in args.tag:
         dockerfile.copy("--from=nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu22.04 /usr/local/cuda-12.2", "/usr/local/cuda-12.2", src_img="nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu22.04")
-        # dockerfile.copy("--from=nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu22.04 /usr/local/nvidia", "/usr/local/nvidia", src_img="nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu22.04")
-        dockerfile.run("rm /usr/local/cuda /usr/local/cuda-12 && ln -sf cuda-12.2 /usr/local/cuda && ln -sf cuda-12.2 /usr/local/cuda-12")
-        # dockerfile.run("echo '/usr/local/cuda/targets/x86_64-linux/lib' >> /etc/ld.so.conf.d/000_cuda.conf && \
-        #     echo '/usr/local/cuda-12/targets/x86_64-linux/lib' >> /etc/ld.so.conf.d/988_cuda-12.conf && \
-        #     ( echo '/usr/local/nvidia/lib'; echo '/usr/local/nvidia/lib64' ) >> /etc/ld.so.conf.d/nvidia.conf && \
-        #     ldconfig")
+        dockerfile.run("rm /usr/local/cuda /usr/local/cuda-12; ln -sf cuda-12.2 /usr/local/cuda && ln -sf cuda-12.2 /usr/local/cuda-12")
         dockerfile.env(**{
             'CUDA_HOME' : "/usr/local/cuda",
             'PATH' : '${CUDA_HOME}/bin:${PATH}'

--- a/opencl_docker/__main__.py
+++ b/opencl_docker/__main__.py
@@ -102,6 +102,18 @@ def install_rocm_drivers(dockerfile: Dockerfile, args: Any):
             "ROCR_VISIBLE_DEVICES": "all",
             #"HIP_VISIBLE_DEVICES": "all"
         })
+    if platform.system() == "Windows":
+        dockerfile.run("apt-get update && \
+                       wget https://repo.radeon.com/amdgpu-install/7.1.1/ubuntu/noble/amdgpu-install_7.1.1.70101-1_all.deb && \
+                       yes Y | apt-get install -y ./amdgpu-install_7.1.1.70101-1_all.deb")
+        dockerfile.run("yes Y | amdgpu-install --uninstall")
+        dockerfile.run("apt-get remove -y ./amdgpu-install_7.1.1.70101-1_all.deb")
+        dockerfile.run("apt-get update && apt autoremove -y &&\
+                       wget https://repo.radeon.com/amdgpu-install/6.4.2.1/ubuntu/noble/amdgpu-install_6.4.60402-1_all.deb && \
+                       yes Y | apt-get install -y ./amdgpu-install_6.4.60402-1_all.deb --allow-downgrades")
+        #dockerfile.run("amdgpu-install -y --usecase=wsl,rocm,opencl --no-dkms")
+        dockerfile.run("amdgpu-install -y --usecase=wsl,rocm,opencl")
+        dockerfile.run("apt-get install -y rocm-opencl-runtime rocm-opencl-dev amd-container-toolkit ocl-icd-opencl-dev opencl-headers clinfo")
     
 def install_opencl_intercept_layer(dockerfile: Dockerfile):
     dockerfile.run("git clone https://github.com/intel/opencl-intercept-layer.git /opencl-intercept-layer")

--- a/opencl_docker/__main__.py
+++ b/opencl_docker/__main__.py
@@ -135,7 +135,7 @@ def install_rocm_drivers(dockerfile: Dockerfile, args: Any):
                        yes Y | apt-get install -y ./amdgpu-install_6.4.60402-1_all.deb --allow-downgrades")
         #dockerfile.run("amdgpu-install -y --usecase=wsl,rocm,opencl --no-dkms")
         dockerfile.run("amdgpu-install -y --usecase=wsl,rocm,opencl")
-        dockerfile.run("apt-get install -y rocm-opencl-runtime rocm-opencl-dev amd-container-toolkit ocl-icd-opencl-dev opencl-headers clinfo")
+        dockerfile.run("apt-get install -y rocm-opencl-runtime rocm-opencl-dev ocl-icd-opencl-dev opencl-headers clinfo")
     
 def install_opencl_intercept_layer(dockerfile: Dockerfile):
     dockerfile.run("git clone https://github.com/intel/opencl-intercept-layer.git /opencl-intercept-layer")


### PR DESCRIPTION
build with

``` bash
python3 -m opencl_docker --image rocm/dev-ubuntu-24.04 --output Dockerfile && docker build . -t cse160-opencl:rocm
```

must be built in docker engine only, will not build if docker desktop is open

Linux devcontainer script:
```json
{
	"image": "cse160-opencl:rocm",
	"runArgs": [
		"--device", "/dev/kfd",
		"--device", "/dev/dri",
		"--security-opt", "seccomp=unconfined",
		//"--group-add", "video",
		//"--group-add", "render",
		//"--ipc=host",
		"-e", "AMD_VISIBLE_DEVICES=all"
		],
	"customizations": {
		"vscode": {
			"extensions": [
				"ms-vscode.cpptools-extension-pack"
			]
		}
	}
}
```

Currently rocm-smi and amd-smi can access the gpu, but rocminfo and clinfo cannot


Windows devcontainer script:

```json
{
	"image": "cse160-opencl:rocm",
	"runArgs": [
		"--device", "/dev/dxg",
		"--device", "/dev/dri",
		"--security-opt", "seccomp=unconfined",
		"-e", "AMD_VISIBLE_DEVICES=all"
		],
	"customizations": {
		"vscode": {
			"extensions": [
				"ms-vscode.cpptools-extension-pack"
			]
		}
	}
}

```